### PR TITLE
Update Chrome manifest from V2 to V3

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -4,8 +4,11 @@
   "description": "Connects to our accompanying Elgato Stream Deck plugin to create physical controls for your Google Meet calls.",
   "author": "Chris Regado",
   "homepage_url": "https://github.com/ChrisRegado/streamdeck-googlemeet",
-  "manifest_version": 2,
-  "permissions": ["https://meet.google.com/*"],
+  "manifest_version": 3,
+  "permissions": [],
+  "host_permissions": [
+    "https://meet.google.com/*"
+  ],
   "content_scripts": [
     {
       "matches": ["https://meet.google.com/*"],
@@ -28,3 +31,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
Currently an error appears in Chrome when loading the extension into the browser warning of the deprecation of manifest V2 in favor of manifest V3. This PR upgrades the manifest to V3 following [this guide](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/) to eliminate this error.

![image](https://user-images.githubusercontent.com/2281616/167689736-85c9c2a5-8090-4774-8dfd-8528a828ce2f.png)
