### PR TITLE
manifest.json: add gecko id

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -32,6 +32,11 @@
       ],
       "run_at": "document_idle"
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{48fc7cf2-9903-4618-9bb9-27ffcaa64814}"
+    }
+  }
 }
 


### PR DESCRIPTION
This is a requirement for Firefox add-ons using manifest v3.  The ID can take the form of an email-like identifier or a UUID.  A quick survey of my installed add-ons shows that most developers seem to use the UUID, so I just generated one locally.

Updates #4