### PR TITLE
Update hand_event_handler for Italian language

### DIFF
--- a/browser-extension/event_handlers/hand_event_handler.js
+++ b/browser-extension/event_handlers/hand_event_handler.js
@@ -5,6 +5,7 @@ class HandEventHandler extends LabelBasedToggleEventHandler {
     ["Melden", "Meldung zurückziehen"],      // German
     ["Levantar la mano", "Bajar la mano"],   // Spanish
     ["Levantar a mão", "Abaixar a mão"],     // Portuguese
+    ["Alza la mano", "Abbassa la mano"],     // Italian
   ];
 
   _sendMuteState = () => {


### PR DESCRIPTION
As per title, adding the Hand events available for Italian, as I unfortunately see that sometimes even changing the language for the personal account, Meet keep being in the workspace language if set that way.
Tested locally and it seems working fine.

BTW: Nice extension, really useful!