### PR TITLE
feat: Add ability to close leave dialog

### DIFF
--- a/browser-extension/event_handlers/leave_call_event_handler.js
+++ b/browser-extension/event_handlers/leave_call_event_handler.js
@@ -7,9 +7,18 @@ class LeaveCallEventHandler extends SDEventHandler {
   }
 
   _leaveCall = () => {
-    const button = document.querySelector('[jsname="CQylAd"]');
+    const leaveDialogPresent = document.querySelector('[jscontroller="ZakeSe"]');
+    if(leaveDialogPresent) {
+      this._leaveCallAction('[data-mdc-dialog-action="Pd96ce"]', 'Leave Call dialog');
+    } else {
+      this._leaveCallAction('[jsname="CQylAd"]', 'Leave Call button');
+    }
+  }
+
+  _leaveCallAction = (selector, buttonType) => {
+    const button = document.querySelector(selector);
     if (!button) {
-      throw new ControlsNotFoundError("No Leave Call button found!")
+      throw new ControlsNotFoundError("No " + buttonType + " found!")
     }
     button.click();
   }


### PR DESCRIPTION
Closes #45 

## Description
This feature adds the ability to close the "End the call or just leave?" dialog box without having to navigate back to the window. To avoid having to add another button, I allow it to be activated by pressing the existing leave button a second time. 