### PR TITLE
fix(browser-extension): harden Meet participants sidepanel selector

### DIFF
--- a/browser-extension/event_handlers/side_panel_event_handler.js
+++ b/browser-extension/event_handlers/side_panel_event_handler.js
@@ -3,10 +3,70 @@
  */
 class SidepanelEventHandler extends SDEventHandler {
 
+  _isLikelyVisible = (element) => {
+    if (!element) {
+      return false;
+    }
+    const style = window.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return false;
+    }
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0;
+  }
+
+  _isExcludedControl = (element) => {
+    if (!element) {
+      return true;
+    }
+    const text = (
+      (element.textContent || "") + " " +
+      ((element.getAttribute && element.getAttribute("aria-label")) || "") + " " +
+      ((element.getAttribute && element.getAttribute("title")) || "")
+    ).toLowerCase();
+
+    const blockedHints = [
+      "call feature notifications",
+      "feature notifications and actions",
+      "press the down arrow to open the hover tray",
+      "hover tray",
+      "notifications and actions",
+    ];
+
+    return blockedHints.some((hint) => text.includes(hint));
+  }
+
+  _toggleParticipantsByKnownMeetSelector = () => {
+    // Observed in newer Meet UI: inner span for People tab icon.
+    const icon = document.querySelector('span[jsname="WyRtCb"]');
+    if (!icon) {
+      return false;
+    }
+
+    const clickable = icon.closest('button,[role="button"],div[tabindex],div[jsaction]');
+    if (!clickable || this._isExcludedControl(clickable) || !this._isLikelyVisible(clickable)) {
+      return false;
+    }
+
+    clickable.click();
+    return true;
+  }
+
   _toggleSidepanel = (sidepanelTabId) => {
+    // Handle participants more defensively because Meet's panel controls changed.
+    if (sidepanelTabId === 1) {
+      if (this._toggleParticipantsByKnownMeetSelector()) {
+        return;
+      }
+    }
+
     const toggleSelector = `[jsname="A5il2e"][data-panel-id="${sidepanelTabId}"]`;
     const sidepanelToggleButton = document.querySelector(toggleSelector);
-    if (sidepanelToggleButton) {
+    if (
+      sidepanelToggleButton &&
+      !this._isExcludedControl(sidepanelToggleButton) &&
+      this._isLikelyVisible(sidepanelToggleButton)
+    ) {
       sidepanelToggleButton.click();
     } else {
       this._throwNotFoundError();


### PR DESCRIPTION
## Summary
Fixes Google Meet sidepanel breakage where the **Toggle Participants** action can fail or hit the wrong control in newer Meet UI variants.

## What changed
- Added a participants-specific fallback selector for newer Meet markup:
  - `span[jsname="WyRtCb"]` -> nearest clickable ancestor
- Added guard logic to avoid clicking non-target sidepanel controls such as:
  - "Call feature notifications and actions"
- Added basic visibility checks before clicking sidepanel controls.

## Why
Recent Meet UI updates changed/added sidepanel controls. The existing selector:
- `[jsname="A5il2e"][data-panel-id="1"]`
can be missing or can match an unintended control depending on layout/experiment flags.

## Scope
- Browser extension only (`browser-extension/event_handlers/side_panel_event_handler.js`)
- No plugin protocol changes
- No MQTT or custom local bridge changes

## Manual test
- In an active Meet call:
  - Press **Toggle Chat** -> chat panel toggles
  - Press **Toggle Participants** -> participants panel toggles
  - Verify participants no longer opens/clicks notification tray controls