### PR TITLE
Move Meet socket to background

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,0 +1,208 @@
+// The localhost port our Stream Deck plugin is listening on.
+const STREAM_DECK_PORT = 2394;
+
+const RECONNECTION_INTERVAL_SECS = 2;
+const HEARTBEAT_INTERVAL_SECS = 20;
+const HEARTBEAT_EVENT_NAME = "keepAlive";
+const WEBSOCKET_OPEN_STATE = 1;
+const PORT_NAME = "streamdeck-googlemeet";
+
+const MESSAGE_TYPES = Object.freeze({
+  BROWSER_EVENT: "browserEvent",
+  STREAM_DECK_CONNECTION_OPENED: "streamDeckConnectionOpened",
+  STREAM_DECK_EVENT: "streamDeckEvent",
+});
+
+/**
+ * Owns the localhost websocket in extension context and relays messages between
+ * the Stream Deck plugin and Meet content scripts.
+ */
+class StreamDeckBackgroundBridge {
+
+  constructor({
+    webSocketFactory = (url) => new WebSocket(url),
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+  } = {}) {
+    this._webSocketFactory = webSocketFactory;
+    this._setTimeout = setTimeoutFn;
+    this._clearTimeout = clearTimeoutFn;
+    this._setInterval = setIntervalFn;
+    this._clearInterval = clearIntervalFn;
+
+    this._ports = new Set();
+    this._socket = null;
+    this._heartbeatIntervalId = null;
+    this._reconnectTimeoutId = null;
+  }
+
+  initialize = () => {
+    chrome.runtime.onConnect.addListener((port) => {
+      if (port.name !== PORT_NAME) {
+        return;
+      }
+      this.addPort(port);
+    });
+  }
+
+  addPort = (port) => {
+    this._ports.add(port);
+
+    port.onMessage.addListener((message) => {
+      this._handlePortMessage(message);
+    });
+
+    port.onDisconnect.addListener(() => {
+      this._ports.delete(port);
+      if (!this._ports.size) {
+        this._stopReconnects();
+        this._closeSocket();
+      }
+    });
+
+    if (this._isSocketOpen()) {
+      this._notifyConnectionOpened(port);
+      return;
+    }
+
+    this._createWebsocket();
+  }
+
+  _handlePortMessage = (message) => {
+    if (message?.type !== MESSAGE_TYPES.BROWSER_EVENT) {
+      return;
+    }
+
+    this._sendToSocket(message.payload);
+  }
+
+  _sendToSocket = (message) => {
+    if (!this._isSocketOpen()) {
+      return;
+    }
+
+    this._socket.send(JSON.stringify(message));
+  }
+
+  _isSocketOpen = () => {
+    return this._socket && this._socket.readyState === WEBSOCKET_OPEN_STATE;
+  }
+
+  _createWebsocket = () => {
+    if (!this._ports.size) {
+      return;
+    }
+    if (this._socket && this._socket.readyState !== 3) {
+      return;
+    }
+
+    this._stopReconnects();
+    this._socket = this._webSocketFactory(`ws://127.0.0.1:${STREAM_DECK_PORT}`);
+
+    this._socket.onerror = (event) => {
+      console.error(
+        "WebSocket error. Closing socket and reconnecting. Error: ",
+        event
+      );
+      this._closeSocket();
+    };
+
+    this._socket.onclose = () => {
+      this._socket = null;
+      this._stopHeartbeat();
+
+      if (!this._ports.size) {
+        return;
+      }
+
+      this._reconnectTimeoutId = this._setTimeout(() => {
+        this._reconnectTimeoutId = null;
+        this._createWebsocket();
+      }, RECONNECTION_INTERVAL_SECS * 1000);
+    };
+
+    this._socket.onopen = () => {
+      this._startHeartbeat();
+      this._broadcast({
+        type: MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED,
+      });
+    };
+
+    this._socket.onmessage = (event) => {
+      let jsonMessage;
+      try {
+        jsonMessage = JSON.parse(event.data);
+      } catch (e) {
+        console.error("Failed to parse message from Stream Deck plugin.", e);
+        return;
+      }
+
+      this._broadcast({
+        type: MESSAGE_TYPES.STREAM_DECK_EVENT,
+        payload: jsonMessage,
+      });
+    };
+  }
+
+  _broadcast = (message) => {
+    this._ports.forEach((port) => {
+      try {
+        port.postMessage(message);
+      } catch (e) {
+        console.error("Failed to relay message to Meet content script.", e);
+      }
+    });
+  }
+
+  _notifyConnectionOpened = (port) => {
+    port.postMessage({
+      type: MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED,
+    });
+  }
+
+  _startHeartbeat = () => {
+    this._stopHeartbeat();
+    this._heartbeatIntervalId = this._setInterval(() => {
+      this._sendToSocket({ event: HEARTBEAT_EVENT_NAME });
+    }, HEARTBEAT_INTERVAL_SECS * 1000);
+  }
+
+  _stopHeartbeat = () => {
+    if (this._heartbeatIntervalId) {
+      this._clearInterval(this._heartbeatIntervalId);
+      this._heartbeatIntervalId = null;
+    }
+  }
+
+  _stopReconnects = () => {
+    if (this._reconnectTimeoutId) {
+      this._clearTimeout(this._reconnectTimeoutId);
+      this._reconnectTimeoutId = null;
+    }
+  }
+
+  _closeSocket = () => {
+    this._stopHeartbeat();
+    if (this._socket) {
+      const socket = this._socket;
+      this._socket = null;
+      socket.onclose = null;
+      socket.close();
+    }
+  }
+
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    MESSAGE_TYPES,
+    StreamDeckBackgroundBridge,
+  };
+}
+
+if (typeof chrome !== "undefined" && chrome.runtime?.onConnect) {
+  const bridge = new StreamDeckBackgroundBridge();
+  bridge.initialize();
+}

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -19,8 +19,8 @@ class StreamDeckBackgroundBridge {
 
   constructor({
     webSocketFactory = (url) => new WebSocket(url),
-    setTimeoutFn = setTimeout,
-    clearTimeoutFn = clearTimeout,
+    setTimeoutFn = (...args) => setTimeout(...args),
+    clearTimeoutFn = (...args) => clearTimeout(...args),
   } = {}) {
     this._webSocketFactory = webSocketFactory;
     this._setTimeout = setTimeoutFn;

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -2,8 +2,6 @@
 const STREAM_DECK_PORT = 2394;
 
 const RECONNECTION_INTERVAL_SECS = 2;
-const HEARTBEAT_INTERVAL_SECS = 20;
-const HEARTBEAT_EVENT_NAME = "keepAlive";
 const WEBSOCKET_OPEN_STATE = 1;
 const PORT_NAME = "streamdeck-googlemeet";
 
@@ -23,18 +21,13 @@ class StreamDeckBackgroundBridge {
     webSocketFactory = (url) => new WebSocket(url),
     setTimeoutFn = setTimeout,
     clearTimeoutFn = clearTimeout,
-    setIntervalFn = setInterval,
-    clearIntervalFn = clearInterval,
   } = {}) {
     this._webSocketFactory = webSocketFactory;
     this._setTimeout = setTimeoutFn;
     this._clearTimeout = clearTimeoutFn;
-    this._setInterval = setIntervalFn;
-    this._clearInterval = clearIntervalFn;
 
     this._ports = new Set();
     this._socket = null;
-    this._heartbeatIntervalId = null;
     this._reconnectTimeoutId = null;
   }
 
@@ -107,24 +100,20 @@ class StreamDeckBackgroundBridge {
         event
       );
       this._closeSocket();
+      if (this._ports.size) {
+        this._scheduleReconnect();
+      }
     };
 
     this._socket.onclose = () => {
       this._socket = null;
-      this._stopHeartbeat();
 
-      if (!this._ports.size) {
-        return;
+      if (this._ports.size) {
+        this._scheduleReconnect();
       }
-
-      this._reconnectTimeoutId = this._setTimeout(() => {
-        this._reconnectTimeoutId = null;
-        this._createWebsocket();
-      }, RECONNECTION_INTERVAL_SECS * 1000);
     };
 
     this._socket.onopen = () => {
-      this._startHeartbeat();
       this._broadcast({
         type: MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED,
       });
@@ -162,18 +151,12 @@ class StreamDeckBackgroundBridge {
     });
   }
 
-  _startHeartbeat = () => {
-    this._stopHeartbeat();
-    this._heartbeatIntervalId = this._setInterval(() => {
-      this._sendToSocket({ event: HEARTBEAT_EVENT_NAME });
-    }, HEARTBEAT_INTERVAL_SECS * 1000);
-  }
-
-  _stopHeartbeat = () => {
-    if (this._heartbeatIntervalId) {
-      this._clearInterval(this._heartbeatIntervalId);
-      this._heartbeatIntervalId = null;
-    }
+  _scheduleReconnect = () => {
+    this._stopReconnects();
+    this._reconnectTimeoutId = this._setTimeout(() => {
+      this._reconnectTimeoutId = null;
+      this._createWebsocket();
+    }, RECONNECTION_INTERVAL_SECS * 1000);
   }
 
   _stopReconnects = () => {
@@ -184,7 +167,6 @@ class StreamDeckBackgroundBridge {
   }
 
   _closeSocket = () => {
-    this._stopHeartbeat();
     if (this._socket) {
       const socket = this._socket;
       this._socket = null;

--- a/browser-extension/main.js
+++ b/browser-extension/main.js
@@ -22,6 +22,6 @@ const eventHandlers = [
   new ZenModeEventHandler(connectionManager),
 ];
 
-connectionManager.initialize();
 eventHandlers.forEach((handler) => connectionManager.registerEventHandler(handler));
 eventHandlers.forEach((handler) => handler.initialize());
+connectionManager.initialize();

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -6,6 +6,9 @@
   "homepage_url": "https://github.com/ChrisRegado/streamdeck-googlemeet",
   "manifest_version": 3,
   "permissions": [],
+  "background": {
+    "service_worker": "background.js"
+  },
   "host_permissions": [
     "https://meet.google.com/*"
   ],

--- a/browser-extension/manifest_firefox_stub.json
+++ b/browser-extension/manifest_firefox_stub.json
@@ -1,4 +1,7 @@
 {
+  "background": {
+    "scripts": ["background.js"]
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "{233c4f86-64fb-11f0-ad1e-00155d1f8e7e}",

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "clean": "node scripts/clean.js",
+    "test": "node --test tests/*.test.js",
     "package-chrome": "node scripts/package-chrome.js",
     "package-firefox": "web-ext build --source-dir=build/firefox --artifacts-dir=build --filename=firefox-extension.zip --overwrite-dest",
     "sign-firefox": "web-ext sign --channel=unlisted --source-dir=build/firefox --artifacts-dir=build",

--- a/browser-extension/scripts/build.js
+++ b/browser-extension/scripts/build.js
@@ -54,9 +54,13 @@ function renderFirefoxManifest(chromeManifestPath, firefoxStubPath, outputPath, 
 // Parse a web extension manifest.json file to extract all referenced scripts
 function listFilesInManifest(manifestPath) {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  return manifest.content_scripts?.flatMap(contentScript => {
+  const contentScriptFiles = manifest.content_scripts?.flatMap(contentScript => {
     return contentScript.js;
-  });
+  }) || [];
+  const backgroundFiles = manifest.background?.service_worker
+    ? [manifest.background.service_worker]
+    : [];
+  return [...contentScriptFiles, ...backgroundFiles];
 }
 
 // Copy source files to both build directories

--- a/browser-extension/stream_deck_connection_manager.js
+++ b/browser-extension/stream_deck_connection_manager.js
@@ -1,4 +1,6 @@
 const RECONNECTION_INTERVAL_SECS = 2;
+const HEARTBEAT_INTERVAL_SECS = 20;
+const HEARTBEAT_EVENT_NAME = "keepAlive";
 const EXTENSION_PORT_NAME = "streamdeck-googlemeet";
 const MESSAGE_TYPES = Object.freeze({
   BROWSER_EVENT: "browserEvent",
@@ -15,6 +17,7 @@ class StreamDeckConnectionMananger {
   constructor() {
     this._port = null;
     this._reconnectTimeoutId = null;
+    this._heartbeatIntervalId = null;
 
     // Any SDEventHandlers registered to receive inbound events from the Stream Deck.
     this._eventHandlers = [];
@@ -65,6 +68,12 @@ class StreamDeckConnectionMananger {
 
     this._port = chrome.runtime.connect({ name: EXTENSION_PORT_NAME });
 
+    // Send a message every 20s. Any message over a Port resets the service worker's
+    // 30-second idle timer, keeping the worker alive as long as Meet is open.
+    this._heartbeatIntervalId = setInterval(() => {
+      this.sendMessage({ event: HEARTBEAT_EVENT_NAME });
+    }, HEARTBEAT_INTERVAL_SECS * 1000);
+
     this._port.onMessage.addListener((message) => {
       if (message?.type === MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED) {
         this._attemptStateTransmission();
@@ -75,8 +84,13 @@ class StreamDeckConnectionMananger {
 
     this._port.onDisconnect.addListener(() => {
       this._port = null;
+      if (this._heartbeatIntervalId) {
+        clearInterval(this._heartbeatIntervalId);
+        this._heartbeatIntervalId = null;
+      }
       if (this._reconnectTimeoutId) {
         clearTimeout(this._reconnectTimeoutId);
+        this._reconnectTimeoutId = null;
       }
       this._reconnectTimeoutId = setTimeout(() => {
         this._reconnectTimeoutId = null;

--- a/browser-extension/stream_deck_connection_manager.js
+++ b/browser-extension/stream_deck_connection_manager.js
@@ -1,15 +1,20 @@
-// The localhost port our Stream Deck plugin is listening on.
-const STREAM_DECK_PORT = 2394;
-
 const RECONNECTION_INTERVAL_SECS = 2;
+const EXTENSION_PORT_NAME = "streamdeck-googlemeet";
+const MESSAGE_TYPES = Object.freeze({
+  BROWSER_EVENT: "browserEvent",
+  STREAM_DECK_CONNECTION_OPENED: "streamDeckConnectionOpened",
+  STREAM_DECK_EVENT: "streamDeckEvent",
+});
 
 /**
- * Manages our websocket that connects this browser extension to the Stream Deck plugin.
+ * Manages our runtime connection to the background extension worker, which in
+ * turn owns the localhost websocket to the Stream Deck plugin.
  */
 class StreamDeckConnectionMananger {
 
   constructor() {
-    this._socket = null;
+    this._port = null;
+    this._reconnectTimeoutId = null;
 
     // Any SDEventHandlers registered to receive inbound events from the Stream Deck.
     this._eventHandlers = [];
@@ -20,12 +25,15 @@ class StreamDeckConnectionMananger {
   }
 
   initialize = () => {
-    this._createWebsocket();
+    this._connectToBackground();
   }
 
   sendMessage = (message) => {
-    if (this._socket && this._socket.readyState === WebSocket.OPEN) {
-      this._socket.send(JSON.stringify(message));
+    if (this._port) {
+      this._port.postMessage({
+        type: MESSAGE_TYPES.BROWSER_EVENT,
+        payload: message,
+      });
     }
   }
 
@@ -50,36 +58,31 @@ class StreamDeckConnectionMananger {
     });
   }
 
-  /**
-   * Connect to our Stream Deck websocket and infinitely attempt to reconnect
-   * if we're unsuccessful or the connection drops.
-   */
-  _createWebsocket = () => {
-    this._socket = new WebSocket("ws://127.0.0.1:" + STREAM_DECK_PORT);
+  _connectToBackground = () => {
+    if (this._port) {
+      return;
+    }
 
-    this._socket.onerror = (event) => {
-      console.error(
-        "WebSocket error. Closing socket and reconnecting. Error: ",
-        event
-      );
-      this._socket.close();
-    };
+    this._port = chrome.runtime.connect({ name: EXTENSION_PORT_NAME });
 
-    this._socket.onclose = () => {
-      // Note: This Event fires on disconnection and failure to connect.
-      setTimeout(() => {
-        this._createWebsocket();
+    this._port.onMessage.addListener((message) => {
+      if (message?.type === MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED) {
+        this._attemptStateTransmission();
+      } else if (message?.type === MESSAGE_TYPES.STREAM_DECK_EVENT) {
+        this._eventHandlers.forEach((handler) => handler.handleStreamDeckEvent(message.payload));
+      }
+    });
+
+    this._port.onDisconnect.addListener(() => {
+      this._port = null;
+      if (this._reconnectTimeoutId) {
+        clearTimeout(this._reconnectTimeoutId);
+      }
+      this._reconnectTimeoutId = setTimeout(() => {
+        this._reconnectTimeoutId = null;
+        this._connectToBackground();
       }, RECONNECTION_INTERVAL_SECS * 1000);
-    };
-
-    this._socket.onopen = () => {
-      this._attemptStateTransmission();
-    };
-
-    this._socket.onmessage = (event) => {
-      const jsonMessage = JSON.parse(event.data);
-      this._eventHandlers.forEach((handler) => handler.handleStreamDeckEvent(jsonMessage))
-    };
+    });
   }
 
 }

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -54,8 +54,6 @@ test("broadcasts connection-opened and inbound websocket events to content scrip
   const socket = makeSocket();
   const bridge = new StreamDeckBackgroundBridge({
     webSocketFactory: () => socket,
-    setIntervalFn: () => 1,
-    clearIntervalFn: () => {},
     setTimeoutFn: () => 1,
     clearTimeoutFn: () => {},
   });
@@ -81,8 +79,6 @@ test("forwards browser events from content scripts to the websocket", () => {
   const socket = makeSocket();
   const bridge = new StreamDeckBackgroundBridge({
     webSocketFactory: () => socket,
-    setIntervalFn: () => 1,
-    clearIntervalFn: () => {},
     setTimeoutFn: () => 1,
     clearTimeoutFn: () => {},
   });
@@ -105,8 +101,6 @@ test("closes the websocket when the last content script disconnects", () => {
   const socket = makeSocket();
   const bridge = new StreamDeckBackgroundBridge({
     webSocketFactory: () => socket,
-    setIntervalFn: () => 1,
-    clearIntervalFn: () => {},
     setTimeoutFn: () => 1,
     clearTimeoutFn: () => {},
   });
@@ -118,4 +112,49 @@ test("closes the websocket when the last content script disconnects", () => {
   port.disconnect();
 
   assert.equal(socket.closeCalls, 1);
+});
+
+test("schedules a reconnect when the websocket errors", () => {
+  let timeoutsScheduled = 0;
+  const socket = makeSocket();
+  const bridge = new StreamDeckBackgroundBridge({
+    webSocketFactory: () => socket,
+    setTimeoutFn: () => {
+      timeoutsScheduled += 1;
+      return 1;
+    },
+    clearTimeoutFn: () => {},
+  });
+  const port = makePort();
+
+  bridge.addPort(port);
+  socket.readyState = 1;
+
+  // Simulate an error
+  socket.onerror(new Error("socket error"));
+
+  assert.equal(socket.closeCalls, 1);
+  assert.equal(timeoutsScheduled, 1);
+});
+
+test("schedules a reconnect when the websocket closes", () => {
+  let timeoutsScheduled = 0;
+  const socket = makeSocket();
+  const bridge = new StreamDeckBackgroundBridge({
+    webSocketFactory: () => socket,
+    setTimeoutFn: () => {
+      timeoutsScheduled += 1;
+      return 1;
+    },
+    clearTimeoutFn: () => {},
+  });
+  const port = makePort();
+
+  bridge.addPort(port);
+  socket.readyState = 1;
+
+  socket.close();
+
+  assert.equal(socket.closeCalls, 1);
+  assert.equal(timeoutsScheduled, 1);
 });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1,0 +1,121 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  MESSAGE_TYPES,
+  StreamDeckBackgroundBridge,
+} = require("../background.js");
+
+function makePort() {
+  const messageListeners = [];
+  const disconnectListeners = [];
+
+  return {
+    postedMessages: [],
+    onMessage: {
+      addListener(listener) {
+        messageListeners.push(listener);
+      },
+    },
+    onDisconnect: {
+      addListener(listener) {
+        disconnectListeners.push(listener);
+      },
+    },
+    postMessage(message) {
+      this.postedMessages.push(message);
+    },
+    emitMessage(message) {
+      messageListeners.forEach((listener) => listener(message));
+    },
+    disconnect() {
+      disconnectListeners.forEach((listener) => listener());
+    },
+  };
+}
+
+function makeSocket() {
+  return {
+    readyState: 0,
+    sentMessages: [],
+    closeCalls: 0,
+    send(message) {
+      this.sentMessages.push(message);
+    },
+    close() {
+      this.closeCalls += 1;
+      this.readyState = 3;
+      this.onclose?.();
+    },
+  };
+}
+
+test("broadcasts connection-opened and inbound websocket events to content scripts", () => {
+  const socket = makeSocket();
+  const bridge = new StreamDeckBackgroundBridge({
+    webSocketFactory: () => socket,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => 1,
+    clearTimeoutFn: () => {},
+  });
+  const port = makePort();
+
+  bridge.addPort(port);
+  socket.readyState = 1;
+  socket.onopen();
+  socket.onmessage({
+    data: JSON.stringify({ event: "toggleMic" }),
+  });
+
+  assert.deepEqual(port.postedMessages, [
+    { type: MESSAGE_TYPES.STREAM_DECK_CONNECTION_OPENED },
+    {
+      type: MESSAGE_TYPES.STREAM_DECK_EVENT,
+      payload: { event: "toggleMic" },
+    },
+  ]);
+});
+
+test("forwards browser events from content scripts to the websocket", () => {
+  const socket = makeSocket();
+  const bridge = new StreamDeckBackgroundBridge({
+    webSocketFactory: () => socket,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => 1,
+    clearTimeoutFn: () => {},
+  });
+  const port = makePort();
+
+  bridge.addPort(port);
+  socket.readyState = 1;
+
+  port.emitMessage({
+    type: MESSAGE_TYPES.BROWSER_EVENT,
+    payload: { event: "micMutedState", muted: true },
+  });
+
+  assert.deepEqual(socket.sentMessages, [
+    JSON.stringify({ event: "micMutedState", muted: true }),
+  ]);
+});
+
+test("closes the websocket when the last content script disconnects", () => {
+  const socket = makeSocket();
+  const bridge = new StreamDeckBackgroundBridge({
+    webSocketFactory: () => socket,
+    setIntervalFn: () => 1,
+    clearIntervalFn: () => {},
+    setTimeoutFn: () => 1,
+    clearTimeoutFn: () => {},
+  });
+  const port = makePort();
+
+  bridge.addPort(port);
+  socket.readyState = 1;
+
+  port.disconnect();
+
+  assert.equal(socket.closeCalls, 1);
+});

--- a/streamdeck-plugin/src/browser_websocket_server.py
+++ b/streamdeck-plugin/src/browser_websocket_server.py
@@ -92,7 +92,15 @@ class BrowserWebsocketServer:
         Loop of waiting for and processing inbound websocket messages, until the
         connection dies. Each connection will create one of these coroutines.
         """
+        had_clients = bool(self._ws_clients)
         self._register_client(ws)
+        if not had_clients:
+            for handler in self._handlers:
+                try:
+                    await handler.on_browser_connected()
+                except Exception:
+                    self._logger.exception(
+                        "Connection mananger received an exception from EventHandler!")
         try:
             async for message in ws:
                 self._logger.info(

--- a/streamdeck-plugin/src/browser_websocket_server.py
+++ b/streamdeck-plugin/src/browser_websocket_server.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
 
 class BrowserWebsocketServer:
+    DISCONNECT_NOTIFY_DELAY_SECONDS = 8.0
+
     """
     The BrowserWebsocketServer manages our connection to our browser extension,
     brokering messages between Google Meet and our plugin's EventHandler.
@@ -22,12 +24,17 @@ class BrowserWebsocketServer:
     websockets hanging around, or if we have multiple Meet tabs.
     """
 
-    def __init__(self):
+    def __init__(self, disconnect_notify_delay_seconds: float | None = None):
         """
         Remember to call start() before attempting to use your new instance!
         """
 
         self._logger = logging.getLogger(__name__)
+        self._disconnect_notify_delay_seconds = (
+            disconnect_notify_delay_seconds
+            if disconnect_notify_delay_seconds is not None
+            else self.DISCONNECT_NOTIFY_DELAY_SECONDS
+        )
 
         """
         Store all of the connected sockets we have open to the browser extension,
@@ -40,6 +47,7 @@ class BrowserWebsocketServer:
         Any EventHandlers registered to receive inbound events from the browser extension.
         """
         self._handlers: List["EventHandler"] = []
+        self._disconnect_notify_task: asyncio.Task | None = None
 
     async def start(self, hostname: str, port: int) -> websockets.Server:
         return await websockets.serve(self._message_receive_loop, hostname, port)
@@ -70,6 +78,7 @@ class BrowserWebsocketServer:
         return len(self._ws_clients)
 
     def _register_client(self, ws: websockets.ServerConnection) -> None:
+        self._cancel_disconnect_notification()
         self._ws_clients.add(ws)
         self._logger.info(
             (f"{ws.remote_address} has connected to our browser websocket."
@@ -113,12 +122,51 @@ class BrowserWebsocketServer:
             await self._unregister_client(ws)
 
         if not self._ws_clients:
+            self._schedule_disconnect_notification()
+
+    def _schedule_disconnect_notification(self) -> None:
+        if self._disconnect_notify_task and not self._disconnect_notify_task.done():
+            return
+
+        self._logger.info(
+            ("Scheduling browser disconnect notification in"
+             f" {self._disconnect_notify_delay_seconds} seconds."))
+        self._disconnect_notify_task = asyncio.create_task(
+            self._notify_all_browsers_disconnected_after_delay())
+
+    def _cancel_disconnect_notification(self) -> None:
+        if not self._disconnect_notify_task:
+            return
+
+        if self._disconnect_notify_task.done():
+            self._disconnect_notify_task = None
+            return
+
+        self._logger.info(
+            ("Cancelled pending browser disconnect notification because a"
+             " browser client connected."))
+        self._disconnect_notify_task.cancel()
+        self._disconnect_notify_task = None
+
+    async def _notify_all_browsers_disconnected_after_delay(self) -> None:
+        current_task = asyncio.current_task()
+
+        try:
+            await asyncio.sleep(self._disconnect_notify_delay_seconds)
+            self._logger.info(
+                ("Browser disconnect notification fired after"
+                 f" {self._disconnect_notify_delay_seconds} seconds."))
             for handler in self._handlers:
                 try:
                     await handler.on_all_browsers_disconnected()
                 except Exception:
                     self._logger.exception(
                         "Connection mananger received an exception from EventHandler!")
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._disconnect_notify_task is current_task:
+                self._disconnect_notify_task = None
 
     async def _process_inbound_message(self, message: str | bytes) -> None:
         """

--- a/streamdeck-plugin/src/event_handlers/base_event_handler.py
+++ b/streamdeck-plugin/src/event_handlers/base_event_handler.py
@@ -40,6 +40,13 @@ class EventHandler:
         """
         pass
 
+    async def on_browser_connected(self) -> None:
+        """
+        Called when the first browser extension client connects after we had no
+        connected browser clients.
+        """
+        pass
+
     async def on_all_browsers_disconnected(self) -> None:
         """
         Called when there are no longer any connections to our browser extension

--- a/streamdeck-plugin/src/event_handlers/base_toggle_event_handler.py
+++ b/streamdeck-plugin/src/event_handlers/base_toggle_event_handler.py
@@ -68,6 +68,17 @@ class BaseToggleEventHandler(EventHandler):
     async def on_all_browsers_disconnected(self) -> None:
         await self._set_stream_deck_mute_state(state=SDToggleState.DISCONNECTED)
 
+    async def on_browser_connected(self) -> None:
+        """
+        Re-request current state whenever the browser bridge comes back so we can
+        clear any stale "Disconnected" button state after transient reconnects.
+        """
+        if not self._toggle_contexts or not self._browser_manager.num_connected_clients():
+            return
+
+        await self._browser_manager.send_to_clients(
+            self._make_simple_sd_event(self.BROWSER_STATE_REQUEST_EVENT_TYPE))
+
     async def _key_up_handler(self, event: dict) -> None:
         if self._browser_manager.num_connected_clients():
             """
@@ -99,10 +110,7 @@ class BaseToggleEventHandler(EventHandler):
         # Until we know otherwise, assume there isn't an active Meet call.
         await self._set_stream_deck_mute_state(SDToggleState.DISCONNECTED)
 
-        # Request current mute state from the browser extension.
-        # We'll asynchronously update button states when we get a response.
-        await self._browser_manager.send_to_clients(
-            self._make_simple_sd_event(self.BROWSER_STATE_REQUEST_EVENT_TYPE))
+        await self.on_browser_connected()
 
     async def _will_disappear_handler(self, event: dict) -> None:
         """

--- a/streamdeck-plugin/tests/event_handlers/test_base_toggle_event_handler.py
+++ b/streamdeck-plugin/tests/event_handlers/test_base_toggle_event_handler.py
@@ -16,7 +16,9 @@ class MockedToggleEventHandler(BaseToggleEventHandler):
 
 
 def make_mocked_toggle_handler():
-    handler = MockedToggleEventHandler(AsyncMock(), AsyncMock())
+    browser_manager = AsyncMock()
+    browser_manager.num_connected_clients = MagicMock(return_value=0)
+    handler = MockedToggleEventHandler(AsyncMock(), browser_manager)
     handler._toggle_contexts = [TEST_TOGGLE_CONTEXT]
     return handler
 
@@ -66,6 +68,23 @@ class BaseToggleEventHandlerTests(IsolatedAsyncioTestCase):
 
         self._assert_called_with_json(
             handler._stream_deck.send_outbound_message, expected_sd_event)
+
+    async def test_browser_reconnection_requests_state(self):
+        """
+        Tests that when the browser reconnects, we request fresh state so stale
+        "Disconnected" buttons can recover without a manual button press.
+        """
+        handler = make_mocked_toggle_handler()
+        handler._browser_manager.num_connected_clients = MagicMock(
+            return_value=1)
+        expected_browser_event = {
+            "event": handler.BROWSER_STATE_REQUEST_EVENT_TYPE
+        }
+
+        await handler.on_browser_connected()
+
+        self._assert_called_with_json(
+            handler._browser_manager.send_to_clients, expected_browser_event)
 
     async def test_key_up_toggle(self):
         """
@@ -117,6 +136,8 @@ class BaseToggleEventHandlerTests(IsolatedAsyncioTestCase):
         request to the browser to set the initial button state.
         """
         handler = make_mocked_toggle_handler()
+        handler._browser_manager.num_connected_clients = MagicMock(
+            return_value=1)
         expected_browser_event = {
             "event": handler.BROWSER_STATE_REQUEST_EVENT_TYPE
         }
@@ -135,7 +156,9 @@ class BaseToggleEventHandlerTests(IsolatedAsyncioTestCase):
         Tests that contexts are successfully saved and then removed as buttons
         appear and disappear.
         """
-        handler = MockedToggleEventHandler(AsyncMock(), AsyncMock())
+        browser_manager = AsyncMock()
+        browser_manager.num_connected_clients = MagicMock(return_value=0)
+        handler = MockedToggleEventHandler(AsyncMock(), browser_manager)
 
         await handler.on_stream_deck_event({
             "event": "willAppear",

--- a/streamdeck-plugin/tests/test_browser_websocket_server.py
+++ b/streamdeck-plugin/tests/test_browser_websocket_server.py
@@ -1,7 +1,27 @@
+import asyncio
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, call
 
 from src.browser_websocket_server import BrowserWebsocketServer
+
+
+class BlockingWebsocket:
+
+    def __init__(self):
+        self.close = AsyncMock()
+        self.remote_address = ("127.0.0.1", 9999)
+        self._disconnect_event = asyncio.Event()
+
+    def disconnect(self):
+        self._disconnect_event.set()
+
+    def __aiter__(self):
+        return self._message_iterator()
+
+    async def _message_iterator(self):
+        await self._disconnect_event.wait()
+        if False:
+            yield "unused"
 
 
 class BrowserWebsocketServerTests(IsolatedAsyncioTestCase):
@@ -60,19 +80,23 @@ class BrowserWebsocketServerTests(IsolatedAsyncioTestCase):
 
         mock_websocket.close.assert_called_once()
 
-    async def test_browser_disconnected_callback_called(self):
+    async def test_browser_disconnected_callback_called_after_delay(self):
         """
         Test that our EventHandler's on_all_browsers_disconnected is called
-        once there are no connected clients.
+        once there are no connected clients for the full debounce window.
         """
         event_handler = AsyncMock()
-        server = BrowserWebsocketServer()
+        server = BrowserWebsocketServer(disconnect_notify_delay_seconds=0.01)
         server.register_event_handler(event_handler)
         mock_websocket = AsyncMock()
 
         await server._message_receive_loop(mock_websocket)
+        event_handler.on_all_browsers_disconnected.assert_not_called()
+
+        await asyncio.sleep(0.02)
 
         event_handler.on_all_browsers_disconnected.assert_called_with()
+        self.assertIsNone(server._disconnect_notify_task)
 
     async def test_browser_connected_callback_called(self):
         """
@@ -104,6 +128,54 @@ class BrowserWebsocketServerTests(IsolatedAsyncioTestCase):
 
         event_handler.on_all_browsers_disconnected.assert_not_called()
         event_handler.on_browser_connected.assert_not_called()
+
+    async def test_transient_browser_disconnect_suppressed_within_window(self):
+        """
+        Test that transient websocket disconnects do not notify handlers when a
+        browser reconnects before the debounce window expires.
+        """
+        event_handler = AsyncMock()
+        server = BrowserWebsocketServer(disconnect_notify_delay_seconds=0.05)
+        server.register_event_handler(event_handler)
+
+        await server._message_receive_loop(AsyncMock())
+
+        blocking_websocket = BlockingWebsocket()
+        reconnect_task = asyncio.create_task(
+            server._message_receive_loop(blocking_websocket))
+        await asyncio.sleep(0.06)
+
+        event_handler.on_all_browsers_disconnected.assert_not_called()
+
+        blocking_websocket.disconnect()
+        await reconnect_task
+        server._disconnect_notify_task.cancel()
+        await asyncio.sleep(0)
+
+    async def test_disconnect_notification_task_cancelled_on_reconnect(self):
+        """
+        Test that a pending disconnect notification task is cancelled when a
+        new browser websocket reconnects within the debounce window.
+        """
+        server = BrowserWebsocketServer(disconnect_notify_delay_seconds=0.05)
+
+        await server._message_receive_loop(AsyncMock())
+        disconnect_notify_task = server._disconnect_notify_task
+        self.assertIsNotNone(disconnect_notify_task)
+        self.assertFalse(disconnect_notify_task.done())
+
+        blocking_websocket = BlockingWebsocket()
+        reconnect_task = asyncio.create_task(
+            server._message_receive_loop(blocking_websocket))
+        await asyncio.sleep(0.01)
+
+        self.assertTrue(disconnect_notify_task.cancelled())
+        self.assertIsNone(server._disconnect_notify_task)
+
+        blocking_websocket.disconnect()
+        await reconnect_task
+        server._disconnect_notify_task.cancel()
+        await asyncio.sleep(0)
 
     async def test_socket_messages_read(self):
         """

--- a/streamdeck-plugin/tests/test_browser_websocket_server.py
+++ b/streamdeck-plugin/tests/test_browser_websocket_server.py
@@ -74,6 +74,20 @@ class BrowserWebsocketServerTests(IsolatedAsyncioTestCase):
 
         event_handler.on_all_browsers_disconnected.assert_called_with()
 
+    async def test_browser_connected_callback_called(self):
+        """
+        Test that our EventHandler's on_browser_connected is called when the
+        first browser client connects.
+        """
+        event_handler = AsyncMock()
+        server = BrowserWebsocketServer()
+        server.register_event_handler(event_handler)
+        mock_websocket = AsyncMock()
+
+        await server._message_receive_loop(mock_websocket)
+
+        event_handler.on_browser_connected.assert_called_with()
+
     async def test_browser_disconnected_callback_not_called(self):
         """
         Test that our EventHandler's on_all_browsers_disconnected is not called when
@@ -89,6 +103,7 @@ class BrowserWebsocketServerTests(IsolatedAsyncioTestCase):
         await server._message_receive_loop(mock_websocket_2)
 
         event_handler.on_all_browsers_disconnected.assert_not_called()
+        event_handler.on_browser_connected.assert_not_called()
 
     async def test_socket_messages_read(self):
         """


### PR DESCRIPTION
## Summary
Fixes browser-side connection failures on newer Chrome/macOS setups by moving the localhost Stream Deck websocket out of the Meet content script and into extension background context.

Also fixes stale `Disconnected` button states after transient reconnects by having the plugin re-request current state when the browser bridge comes back.

## What changed
- Added a background bridge that owns the `ws://127.0.0.1:2394` connection
- Relayed messages between the Meet content script and background worker via `chrome.runtime.connect`
- Kept the existing event handler contract intact in the content script layer
- Added unit tests for the browser-extension background bridge message flow
- Updated the browser-extension build to include the background script
- Kept Firefox compatibility by overriding the background manifest in the Firefox stub
- Added a plugin-side reconnect callback so toggle buttons request fresh state when browser clients reconnect
- Added plugin tests for reconnect callbacks and button-state resync

## Why
The previous design opened the localhost websocket directly from the Meet page context. On newer Chrome/macOS combinations, that connection can fail even when the Stream Deck plugin is running and listening locally.

After moving the socket into extension background context, brief reconnects could still leave Stream Deck toggle buttons showing a stale `Disconnected` badge until some later manual interaction triggered a fresh state update.

This change keeps the existing browser/plugin protocol intact while fixing both the page-context transport failure and the reconnect resync gap.

## Scope
- Browser extension transport changes
- Stream Deck plugin reconnect/state-resync changes
- No plugin protocol changes
- No Meet control behavior changes beyond connection handling and state recovery

## Manual test
- Load the unpacked browser extension
- Join an active Google Meet call
- Confirm the extension connects without the repeated websocket error loop
- Confirm Stream Deck actions still toggle/update Meet controls normally
- Leave the Meet tab idle long enough to hit any transient reconnect path and confirm mic/camera buttons recover their real state without needing a manual button press to clear a `Disconnected` badge
